### PR TITLE
fix bugs and code for Mac

### DIFF
--- a/medy
+++ b/medy
@@ -99,7 +99,8 @@ function where_dir {
 }
 
 function cygwin_arch {
-  arch | awk '{sub("i686", "x86"); print $0;}'
+  # arch | awk '{sub("i686", "x86"); print $0;}'
+  uname -m | awk '{sub("i686", "x86"); print $0;}'
 }
 
 function encode_mirror_url {

--- a/medy
+++ b/medy
@@ -25,6 +25,20 @@
 # THE SOFTWARE.
 #
 
+# # for debug
+# exec 2> tmp.log
+# set -vx
+
+# # using GNU sed (for dev)
+# function sed {
+#   case `uname` in
+#     Darwin) # mac os
+#       gsed "$@" ;;
+#     *)
+#       sed "$@" ;;
+#   esac
+# }
+
 medylogo="
   ._ _  _  _|
   | | |(/_(_|\/
@@ -283,7 +297,7 @@ function medy-search {
 }
 
 function medy-info {
-
+  checkpackages "$@"
   setlab
 
   info="$(grep -wA10 "^@ $1$" $cache/$dir/$arch/setup.ini |\
@@ -605,11 +619,11 @@ function remove-dep {
 }
 
 function medy-uninstall {
-  remove "$@"
+  medy-remove "$@"
 }
 
 function medy-find {
-  search "$@"
+  medy-search "$@"
 }
 
 function medy-upgrade {

--- a/medy
+++ b/medy
@@ -281,7 +281,7 @@ function medy-search {
   local pkg
 
   checkpackages "$@"
-  establish_lab
+  #establish_lab
 
     for pkg do
       echo ""
@@ -342,7 +342,7 @@ function medy-install {
   local script
 
   checkpackages "$@"
-  establish_lab
+  #establish_lab
   noupdate=1
   getsetup
   echo


### PR DESCRIPTION
in Mac, `arch` outputs i385. but expected is x86 or x86_64
so replace `arch` command with `uname -m`
Note `arch` is equivalent to `uname -m` in Linux

and add code for fix bugs
- argument checker in medy-info()
- medy-uninstall() invoke medy-remove()
- medy-find() invoke medy-search()
- command establish_lab is not found
