### PR TITLE
Create Parser for setup.ini

### DIFF
--- a/lib/setup-parser.pl
+++ b/lib/setup-parser.pl
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+sub usage {
+	my $script_name = $0;
+	print "$script_name: perser to read setup.int\n";
+	print "Usage:\n";
+	print "  ./$script_name <package>         to show package info\n";
+	print "  ./$script_name <package> <tag>   to show tagged content on package info\n";
+	exit;
+}
+
+usage() if ( $#ARGV == -1 );
+
+my $pkg_name = $ARGV[0];
+my $tag_name = $ARGV[1];
+
+open(SETUP_INIT, "< ../setup.ini") or die("could not open file");
+
+while (<SETUP_INIT>) {
+	if (/^@ /) {
+		print;
+	}
+}

--- a/lib/setup-parser.pl
+++ b/lib/setup-parser.pl
@@ -1,3 +1,5 @@
+#!/usr/bin/perl
+
 use strict;
 use warnings;
 
@@ -12,13 +14,121 @@ sub usage {
 
 usage() if ( $#ARGV == -1 );
 
+sub show_pkg_all_info {
+	my ($pkg_info) = @_;
+	print "sdesc: $pkg_info->{'sdesc'}\n";
+	print "ldesc: \n";
+	foreach (@{$pkg_info->{'ldesc'}}) {
+		print;
+	}
+	print "\n";
+	print "category: $pkg_info->{'category'}\n";
+	print "requires: $pkg_info->{'requires'}\n";
+	print "version: $pkg_info->{'version'}\n";
+	print "install: $pkg_info->{'install'}\n";
+}
+
+sub show_pkg_info {
+	my ($pkg_info, $tag) = @_;
+	unless ($tag) {
+		show_pkg_all_info(\%$pkg_info);
+	} else {
+		print "$pkg_info->{$tag}\n" or die("tag \"$tag\" is not found.");
+	}
+}
+
 my $pkg_name = $ARGV[0];
 my $tag_name = $ARGV[1];
+my $found_pkg = 0; # false
+my %pkg_info = (
+	'sdesc' => '',
+	'ldesc' => [
+		# each lines
+	],
+	'category' => '',
+	'requires' => '',
+	'version' => '',
+	'install' => ''
+);
+my $on_ldesc = 0; # false
+
+if ( !(exists $pkg_info{$tag_name}) ) {
+	print "no such a tag: $tag_name\n";
+	exit -1;
+}
+
 
 open(SETUP_INIT, "< ../setup.ini") or die("could not open file");
 
 while (<SETUP_INIT>) {
-	if (/^@ /) {
-		print;
+	if (/^@ $pkg_name$/) {
+		$found_pkg = 1; # true
+		next;
 	}
+
+	next unless ($found_pkg);
+
+	# if package is found, tries matching as follows:
+
+	# sdesc
+	if (/^sdesc: "([^\\"]++|\\.)*+"$/) {
+		$pkg_info{'sdesc'} = $1;
+		next;
+	}
+
+	# ldesc
+	if (/^ldesc: /) {
+		$on_ldesc = 1; # true
+	}
+	if (/^ldesc: "([^\\"]++|\\.)*+("?)$/) {
+		push(@{$pkg_info{'ldesc'}}, $1);
+		# when double quote is on end of line, on_ldesc is false.
+		$on_ldesc = 0 if ($2);
+		next;
+	}
+	if ($on_ldesc && /^([^\\"]++|\\.)*("?)$/) {
+		push(@{$pkg_info{'ldesc'}}, $1);
+		# when double quote is on end of line, on_ldesc is false.
+		$on_ldesc = 0 if ($2);
+		next;
+	}
+
+	# category
+	if (/^category: ([^\n]*+)$/) {
+		$pkg_info{'category'} = $1;
+		next;
+	}
+
+	# requires
+	if (/^requires: ([^\n]*+)$/) {
+		$pkg_info{'requires'} = $1;
+		next;
+	}
+
+	# version
+	if (/^version: ([^\n]*+)$/) {
+		$pkg_info{'version'} = $1;
+		next;
+	}
+
+	# install
+	if (/^install: ([^\n]*+)$/) {
+		$pkg_info{'install'} = $1;
+		next;
+	}
+
+	# ignore [prev] info
+	last if (/^\[prev\]$/);
+	# next package
+	last if (/^@ /);
 }
+
+unless ($found_pkg) {
+	exit -1;
+}
+
+
+show_pkg_info(\%pkg_info, "$tag_name");
+
+
+

--- a/lib/setup-parser.pl
+++ b/lib/setup-parser.pl
@@ -97,33 +97,15 @@ while (<SETUP_INIT>) {
 		next;
 	}
 
-	# category
-	if (/^category: ([^\n]*+)$/) {
-		$pkg_info{'category'} = $1;
-		next;
-	}
-
-	# requires
-	if (/^requires: ([^\n]*+)$/) {
-		$pkg_info{'requires'} = $1;
-		next;
-	}
-
-	# version
-	if (/^version: ([^\n]*+)$/) {
-		$pkg_info{'version'} = $1;
-		next;
-	}
-
-	# install
-	if (/^install: ([^\n]*+)$/) {
-		$pkg_info{'install'} = $1;
+	# category, requires, version, install
+	if (/^(category|requires|version|install): ([^\n]*+)$/) {
+		$pkg_info{$1} = $2;
 		next;
 	}
 
 	# ignore [prev] info
 	last if (/^\[prev\]$/);
-	# next package
+	# ignore next package
 	last if (/^@ /);
 }
 

--- a/lib/setup-parser.pl
+++ b/lib/setup-parser.pl
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-my $target_file = "../setup.ini";
+my $target_file = "setup.ini";
 
 sub usage {
 	my $script_name = $0;
@@ -62,7 +62,7 @@ if (defined($tag_name)) {
 }
 
 
-open(SETUP_INIT, "< $target_file") or die("could not open file");
+open(SETUP_INIT, "< $target_file") or die("could not open file \"$target_file\"");
 
 while (<SETUP_INIT>) {
 	if (/^@ $pkg_name$/) {

--- a/lib/setup-parser.pl
+++ b/lib/setup-parser.pl
@@ -32,7 +32,11 @@ sub show_pkg_all_info {
 
 sub show_pkg_info {
 	my ($pkg_info, $tag) = @_;
-	show_pkg_all_info(\%$pkg_info) unless (defined($tag));
+	
+	unless (defined $tag) {
+		show_pkg_all_info(\%$pkg_info);
+		return;
+	}
 
 	if (ref $pkg_info->{$tag} eq 'ARRAY') {
 		foreach (@{$pkg_info->{$tag}}) {
@@ -64,7 +68,7 @@ my %pkg_info = (
 my $on_ldesc = 0; # false
 
 # check if the tag name is valid
-if (defined($tag_name)) {
+if (defined $tag_name) {
 	if ( !(exists $pkg_info{$tag_name}) ) {
 		print "no such a tag: $tag_name\n";
 		exit -1;
@@ -124,7 +128,7 @@ unless ($found_pkg) {
 	exit -1;
 }
 
-if (defined($tag_name)) {
+if (defined $tag_name) {
 	show_pkg_info(\%pkg_info, "$tag_name");
 } else {
 	show_pkg_info(\%pkg_info);

--- a/lib/setup-parser.pl
+++ b/lib/setup-parser.pl
@@ -9,8 +9,8 @@ sub usage {
 	my $script_name = $0;
 	print "$script_name: perser to read setup.int\n";
 	print "Usage:\n";
-	print "  ./$script_name <package>         to show package info\n";
-	print "  ./$script_name <package> <tag>   to show tagged content on package info\n";
+	print "  perl $script_name <package>         to show package info\n";
+	print "  perl $script_name <package> <tag>   to show tagged content on package info\n";
 	print "<tag>:\n";
 	print "  sdesc  ldesc  category  requires  version  install\n";
 	exit;

--- a/lib/setup-parser.pl
+++ b/lib/setup-parser.pl
@@ -3,6 +3,8 @@
 use strict;
 use warnings;
 
+my $target_file = "../setup.ini";
+
 sub usage {
 	my $script_name = $0;
 	print "$script_name: perser to read setup.int\n";
@@ -11,8 +13,6 @@ sub usage {
 	print "  ./$script_name <package> <tag>   to show tagged content on package info\n";
 	exit;
 }
-
-usage() if ( $#ARGV == -1 );
 
 sub show_pkg_all_info {
 	my ($pkg_info) = @_;
@@ -30,12 +30,14 @@ sub show_pkg_all_info {
 
 sub show_pkg_info {
 	my ($pkg_info, $tag) = @_;
-	unless ($tag) {
-		show_pkg_all_info(\%$pkg_info);
-	} else {
+	if (defined($tag)) {
 		print "$pkg_info->{$tag}\n" or die("tag \"$tag\" is not found.");
+	} else {
+		show_pkg_all_info(\%$pkg_info);
 	}
 }
+
+usage() if ( $#ARGV == -1 );
 
 my $pkg_name = $ARGV[0];
 my $tag_name = $ARGV[1];
@@ -52,13 +54,15 @@ my %pkg_info = (
 );
 my $on_ldesc = 0; # false
 
-if ( !(exists $pkg_info{$tag_name}) ) {
-	print "no such a tag: $tag_name\n";
-	exit -1;
+if (defined($tag_name)) {
+	if ( !(exists $pkg_info{$tag_name}) ) {
+		print "no such a tag: $tag_name\n";
+		exit -1;
+	}
 }
 
 
-open(SETUP_INIT, "< ../setup.ini") or die("could not open file");
+open(SETUP_INIT, "< $target_file") or die("could not open file");
 
 while (<SETUP_INIT>) {
 	if (/^@ $pkg_name$/) {
@@ -127,8 +131,12 @@ unless ($found_pkg) {
 	exit -1;
 }
 
+if (defined($tag_name)) {
+	show_pkg_info(\%pkg_info, "$tag_name");
+} else {
+	show_pkg_info(\%pkg_info);
+}
 
-show_pkg_info(\%pkg_info, "$tag_name");
 
 
 

--- a/medy
+++ b/medy
@@ -33,9 +33,9 @@
 # function sed {
 #   case `uname` in
 #     Darwin) # mac os
-#       gsed "$@" ;;
+#       /usr/local/bin/gsed "$@" ;;
 #     *)
-#       sed "$@" ;;
+#       /usr/bin/sed "$@" ;;
 #   esac
 # }
 


### PR DESCRIPTION
I created setup-parser.pl in medy/lib/
it behaves as follows:
- type: `perl lib/setup-parser.pl` to show usage
- type: `perl lib/setup-parser.pl <package>` to show package info
- type: `perl lib/setup-parser.pl <package> <tag>` to show tagged content on package info

for instance

`perl lib/setup-parser.pl vim requires`
