### PR TITLE
Create pkg-depends.pl

### DIFF
--- a/lib/pkg-depends.pl
+++ b/lib/pkg-depends.pl
@@ -19,7 +19,8 @@
 
 use strict;
 use warnings;
-require 'lib/setup-parser.pl';
+use File::Basename;
+require '' . dirname(__FILE__) . '/setup-parser.pl';
 
 package PkgDepends;
 

--- a/lib/pkg-depends.pl
+++ b/lib/pkg-depends.pl
@@ -26,9 +26,8 @@ sub fetch_pkg_depends {
 	my $requires_str = SetupParser::extract_from_setup_init($pkg_name, 'requires');
 	my @requires     = split(/\s+/, $requires_str);
 
-	print "begin: $nest\n";
-	print join(' ', keys %require_pkgs) . "\n";
-	# print "requires_str: $requires_str\n";
+	# print "begin: $nest\n";
+	# print join(' ', keys %require_pkgs) . "\n";
 
 	foreach (@requires) {
 		my $require_pkg = $_;
@@ -38,14 +37,13 @@ sub fetch_pkg_depends {
 		fetch_pkg_depends(\%require_pkgs, $require_pkg, $nest + 1);
 	}
 
-	print "end: $nest\n";
+	# print "end: $nest\n";
 }
 
 fetch_pkg_depends(\%require_pkgs, $pkg_name, 0);
 
-print "---\n";
-foreach (keys %require_pkgs) {
-	print "$_\n";
-}
+# print "---\n";
+
+print join(' ', keys %require_pkgs) . "\n";
 
 

--- a/lib/pkg-depends.pl
+++ b/lib/pkg-depends.pl
@@ -1,0 +1,51 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+require 'lib/setup-parser.pl';
+
+package PkgDepends;
+
+$ENV{'SETUP_INIT_FILE_PATH'}   = "./setup.ini";
+$ENV{'SETUP_PARSER_FILE_PATH'} = "./lib/setup-parser.pl";
+
+sub usage {
+	my $script_name = $0;
+	print "Usage\n";
+	print "  \"perl $script_name <package>\"   to show dependencies of package\n";
+	exit;
+}
+
+usage() if ($#ARGV == -1);
+
+my $pkg_name = $ARGV[0];
+my %require_pkgs = ();
+
+sub fetch_pkg_depends {
+	my ($require_pkgs, $pkg_name, $nest) = @_;
+	my $requires_str = SetupParser::extract_from_setup_init($pkg_name, 'requires');
+	my @requires     = split(/\s+/, $requires_str);
+
+	print "begin: $nest\n";
+	print join(' ', keys %require_pkgs) . "\n";
+	# print "requires_str: $requires_str\n";
+
+	foreach (@requires) {
+		my $require_pkg = $_;
+		my $require_pkg_key = \$require_pkgs->{$_};
+		next if (defined $$require_pkg_key && $$require_pkg_key == 1); # already marked
+		$require_pkgs->{$_} = 1;
+		fetch_pkg_depends(\%require_pkgs, $require_pkg, $nest + 1);
+	}
+
+	print "end: $nest\n";
+}
+
+fetch_pkg_depends(\%require_pkgs, $pkg_name, 0);
+
+print "---\n";
+foreach (keys %require_pkgs) {
+	print "$_\n";
+}
+
+

--- a/lib/setup-parser.pl
+++ b/lib/setup-parser.pl
@@ -38,35 +38,31 @@ sub usage {
 	exit;
 }
 
-sub show_pkg_all_info {
+sub format_pkg_all_info {
 	my ($pkg_info) = @_;
-	print "sdesc: $pkg_info->{'sdesc'}\n";
-	print "ldesc: \n";
-	foreach (@{$pkg_info->{'ldesc'}}) {
-		print;
-	}
-	print "\n";
-	print "category: $pkg_info->{'category'}\n";
-	print "requires: $pkg_info->{'requires'}\n";
-	print "version: $pkg_info->{'version'}\n";
-	print "install: $pkg_info->{'install'}\n";
+	my @each_lines = (
+		"sdesc: $pkg_info->{'sdesc'}",
+		"ldesc: \n" . join('', @{$pkg_info->{'ldesc'}}),
+		"category: $pkg_info->{'category'}",
+		"requires: $pkg_info->{'requires'}",
+		"version: $pkg_info->{'version'}",
+		"install: $pkg_info->{'install'}",
+		"" # ends with \n
+	);
+	return join("\n", @each_lines);
 }
 
-sub show_pkg_info {
+sub format_pkg_info {
 	my ($pkg_info, $tag) = @_;
 	
 	unless (defined $tag) {
-		show_pkg_all_info(\%$pkg_info);
-		return;
+		return format_pkg_all_info(\%$pkg_info);
 	}
 
 	if (ref $pkg_info->{$tag} eq 'ARRAY') {
-		foreach (@{$pkg_info->{$tag}}) {
-			print;
-		}
-		print "\n";
+		return join('', @{$pkg_info->{$tag}})
 	} else {
-		print "$pkg_info->{$tag}\n";
+		return "$pkg_info->{$tag}\n";
 	}
 }
 
@@ -107,7 +103,7 @@ sub extract_from_setup_init {
 
 	while (<$in>) {
 		# find package name
-		if (/^@ $pkg_name$/) {
+		if (/^@ \Q$pkg_name\E$/) {
 			$found_pkg = 1; # true
 			next;
 		}
@@ -156,9 +152,9 @@ sub extract_from_setup_init {
 	}
 
 	if (defined $tag_name) {
-		show_pkg_info(\%pkg_info, "$tag_name");
+		format_pkg_info(\%pkg_info, "$tag_name");
 	} else {
-		show_pkg_info(\%pkg_info);
+		format_pkg_info(\%pkg_info);
 	}
 }
 
@@ -167,7 +163,7 @@ if (__FILE__ eq $0) {
 	usage() if ( $#ARGV == -1 );
 	my $pkg_name = $ARGV[0];
 	my $tag_name = $ARGV[1];
-	extract_from_setup_init($pkg_name, $tag_name);
+	print extract_from_setup_init($pkg_name, $tag_name);
 }
 
 1;

--- a/lib/setup-parser.pl
+++ b/lib/setup-parser.pl
@@ -1,18 +1,20 @@
 #!/usr/bin/perl
 # 
+#   setup-parser.pl -- perser to read setup.int
+# 
 # args:
 #   $package_name <- $ARGV[0]
 #   $tag_name     <- $ARGV[1]
 #     where $tag_name = 'sdesc', 'ldesc', 'category', 'requires', 'version', 'install', undef
 # 
 # input:
-#   if a enviroment variable 'SETUP_INIT_FILE_PATH' is exported, input from its file.
+#   if a enviroment variable 'SETUP_INI_FILE_PATH' is exported, input from its file.
 #   otherwise, input from stdin.
 #   how output the requirements of Vim is as follows:
 #   
 #       cat /path/to/setup.ini | perl setup-parser.pl vim requires
 #   or
-#       export SETUP_INIT_FILE_PATH=/path/to/setup.ini
+#       export SETUP_INI_FILE_PATH=/path/to/setup.ini
 #       perl setup-parser.pl vim requires
 # 
 # return:
@@ -93,7 +95,7 @@ sub extract_from_setup_init {
 
 	# select input (file or stdin)
 	my $in;
-	my $target_file = $ENV{'SETUP_INIT_FILE_PATH'};
+	my $target_file = $ENV{'SETUP_INI_FILE_PATH'};
 	if ($target_file) {
 		open($in, "< $target_file") or die("could not open file \"$target_file\"");
 	} else {
@@ -164,6 +166,7 @@ if (__FILE__ eq $0) {
 	my $pkg_name = $ARGV[0];
 	my $tag_name = $ARGV[1];
 	print extract_from_setup_init($pkg_name, $tag_name);
+} else {
+	1;
 }
 
-1;

--- a/lib/setup-parser.pl
+++ b/lib/setup-parser.pl
@@ -1,9 +1,29 @@
 #!/usr/bin/perl
+# 
+# args:
+#   $package_name <- $ARGV[0]
+#   $tag_name     <- $ARGV[1]
+#     where $tag_name = 'sdesc', 'ldesc', 'category', 'requires', 'version', 'install', undef
+# 
+# input:
+#   if a enviroment variable 'SETUP_INIT_FILE_PATH' is exported, input from its file.
+#   otherwise, input from stdin.
+#   how output the requirements of Vim is as follows:
+#   
+#       cat /path/to/setup.ini | perl setup-parser.pl vim requires
+#   or
+#       export SETUP_INIT_FILE_PATH=/path/to/setup.ini
+#       perl setup-parser.pl vim requires
+# 
+# return:
+#   return -1 if package name is not found in input.
+#   return -1 if tag name is invalid.
+#   if $tag_name is not specified, print $package_name's info.
+#   otherwise, print the tagged content of $package_name.
+# 
 
 use strict;
 use warnings;
-
-our $target_file = "setup.ini";
 
 sub usage {
 	my $script_name = $0;
@@ -75,10 +95,17 @@ if (defined $tag_name) {
 	}
 }
 
+# select input (file or stdin)
+my $in;
+my $target_file = $ENV{'SETUP_INIT_FILE_PATH'};
+if ($target_file) {
+	open($in, "< $target_file") or die("could not open file \"$target_file\"");
+} else {
+	$in = *STDIN
+}
 
-open(SETUP_INIT_FILE, "< $target_file") or die("could not open file \"$target_file\"");
 
-while (<SETUP_INIT_FILE>) {
+while (<$in>) {
 	# find package name
 	if (/^@ $pkg_name$/) {
 		$found_pkg = 1; # true
@@ -96,7 +123,7 @@ while (<SETUP_INIT_FILE>) {
 	}
 
 	# ldesc
-	if (/^ldesc: /) {
+	if (/^ldesc: "/) {
 		$on_ldesc = 1; # true
 	}
 	if (/^ldesc: "([^"]*+)("?)$/) {

--- a/lib/setup-parser.pl
+++ b/lib/setup-parser.pl
@@ -24,13 +24,8 @@
 
 use strict;
 use warnings;
-use Exporter;
 
-our @ISA= qw(Exporter);
-# these CAN be exported.
-our @EXPORT_OK = qw();
-# these are exported by default.
-our @EXPORT = qw(extract_from_setup_init);
+package SetupParser;
 
 sub usage {
 	my $script_name = $0;
@@ -168,8 +163,11 @@ sub extract_from_setup_init {
 }
 
 
-usage() if ( $#ARGV == -1 );
-my $pkg_name = $ARGV[0];
-my $tag_name = $ARGV[1];
-extract_from_setup_init($pkg_name, $tag_name);
+if (__FILE__ eq $0) {
+	usage() if ( $#ARGV == -1 );
+	my $pkg_name = $ARGV[0];
+	my $tag_name = $ARGV[1];
+	extract_from_setup_init($pkg_name, $tag_name);
+}
 
+1;


### PR DESCRIPTION
create pkg-depends.pl and update setup-parser.pl
the pkg-depends.pl script behaves as follows:
- `perl pkg-depends.pl <package>` to show the depended packages of given package name

example of use:

```
$ # in medy/
$ export SETUP_INI_FILE_PATH=./setup.ini
$ perl lib/pkg-depends.pl vim
gawk
libstdc++6
libmpfr4
libgcc1
libcatgets1
bash
libintl8
base-cygwin
libiconv2
perl_base
libreadline7
libcrypt0
tcsh
libgmp10
crypt
tzcode
libattr1
libssp0
libncursesw10
vim-common
xxd
cygwin
terminfo
coreutils
_update-info-dir
$ 
```

if you want a sorted list, type `perl lib/pkg-depends.pl vim | sort`
